### PR TITLE
Fix README.md to use the correct command to generate math.creds file

### DIFF
--- a/episode_06/README.md
+++ b/episode_06/README.md
@@ -27,7 +27,7 @@ nats context save my_org_sys --nsc "nsc://my_org/SYS/sys"
 nats context save my_org_user_a --nsc "nsc://my_org/TEAM_A/user_a"
 nats context save my_org_math --nsc "nsc://my_org/TEAM_B/math"
 
-nats generate creds -n math > math.creds
+nsc generate creds -n math > math.creds
 
 go run math_service.go
 


### PR DESCRIPTION
If we compare https://youtu.be/5pQVjN0ym5w?feature=shared&t=1221 vs the README.md on this repo the command is wrong so this PR updates it to match the video.

I manually tested it works when following the video.